### PR TITLE
Solved issues 44, 47, manufacturer name in devices, add two TFA device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 [Back](./README.md)
 
-## v.2.2.0 ()
+## v.2.2.0 (Dec 26 2025)
 
-- **feat**: Add device TFA Dostmann KLIMA@HOME 30.3060 (based on Mobile Alerts), issue
+- **feat**: Add device TFA Dostmann KLIMA@HOME 30.3060 (based on Mobile Alerts), issue [44](https://github.com/CestLaGalere/mobilealerts/issues/44)
 - **feat**: Add device TFA Dostmann Temperature/Humidity Transmitter for WEATERHUB 30.3303 (based on Mobile Alerts), issue [47](https://github.com/CestLaGalere/mobilealerts/issues/47)
 - **chore**: Add button installation decription in readme
+- **chore**: Show correct manufacturer on device info page, either "Mobile Alerts" or "TFA Dostmann"
 - **fix**: Option Symbol (option flow) removed, threw an error 500 (internal server error), issue [47](https://github.com/CestLaGalere/mobilealerts/issues/47)
 
 ## v2.1.0 (Dec 15 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ## v.2.2.0 (Dec 26 2025)
 
 - **feat**: Add device TFA Dostmann KLIMA@HOME 30.3060 (based on Mobile Alerts), issue [44](https://github.com/CestLaGalere/mobilealerts/issues/44)
-- **feat**: Add device TFA Dostmann Temperature/Humidity Transmitter for WEATERHUB 30.3303 (based on Mobile Alerts), issue [47](https://github.com/CestLaGalere/mobilealerts/issues/47)
-- **chore**: Add button installation decription in readme
+- **feat**: Add device TFA Dostmann Temperature/Humidity Transmitter for WEATHERHUB 30.3303 (based on Mobile Alerts), issue [47](https://github.com/CestLaGalere/mobilealerts/issues/47)
+- **chore**: Add button installation description in readme
 - **chore**: Show correct manufacturer on device info page, either "Mobile Alerts" or "TFA Dostmann"
 - **fix**: Option Symbol (option flow) removed, threw an error 500 (internal server error), issue [47](https://github.com/CestLaGalere/mobilealerts/issues/47)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Back](./README.md)
 
+## v.2.2.0 ()
+
+- **feat**: Add device KLIMA@HOME 30.3060 from TFA (based on Mobile Alerts)
+- **chore**: Add button installation decription in readme
+-
+
 ## v2.1.0 (Dec 15 2025)
 
 - **fix**: Air pressure device MA10238 had wrong humidity key (error) [#40](https://github.com/CestLaGalere/mobilealerts/issues/40)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ## v.2.2.0 ()
 
-- **feat**: Add device KLIMA@HOME 30.3060 from TFA (based on Mobile Alerts)
+- **feat**: Add device TFA Dostmann KLIMA@HOME 30.3060 (based on Mobile Alerts), issue
+- **feat**: Add device TFA Dostmann Temperature/Humidity Transmitter for WEATERHUB 30.3303 (based on Mobile Alerts), issue [47](https://github.com/CestLaGalere/mobilealerts/issues/47)
 - **chore**: Add button installation decription in readme
--
+- **fix**: Option Symbol (option flow) removed, threw an error 500 (internal server error), issue [47](https://github.com/CestLaGalere/mobilealerts/issues/47)
 
 ## v2.1.0 (Dec 15 2025)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ integrates home assistant to the mobilealerts sensor reading service
 see [Version History](ReleaseHistory.md)
 
 ## Installation
+You need to have Home Assistant Community Store (HACS) installed. If you don't have installed HACS yet, read their [documentation](https://www.hacs.xyz/docs/use/).
 
+### Via quick link button
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=CestLaGalere&repository=mobilealerts&category=integration)
+
+### Manually via HACS
 To install this integration you will need to add this as a custom repository in HACS.
 Open HACS page, then click integrations
 Click the three dots top right, select Custom repositories

--- a/custom_components/mobile_alerts/config_flow.py
+++ b/custom_components/mobile_alerts/config_flow.py
@@ -316,24 +316,24 @@ class MobileAlertsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    @staticmethod
-    def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,
-    ) -> config_entries.OptionsFlow:
-        """Get the options flow for this config entry."""
-        return OptionsFlowHandler(config_entry)
+    # @staticmethod
+    # def async_get_options_flow(
+    #     config_entry: config_entries.ConfigEntry,
+    # ) -> config_entries.OptionsFlow:
+    #     """Get the options flow for this config entry."""
+    #     return OptionsFlowHandler(config_entry)
 
 
-class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle options for Mobile Alerts."""
+# class OptionsFlowHandler(config_entries.OptionsFlow):
+#     """Handle options for Mobile Alerts."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
+#     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+#         """Initialize options flow."""
+#         self.config_entry = config_entry
 
-    async def async_step_init(
-        self, user_input: Optional[dict[str, Any]] = None
-    ) -> dict[str, Any]:  # type: ignore[override]
-        """Manage the options."""
-        # For now, no options to manage
-        return self.async_abort(reason="not_implemented")
+#     async def async_step_init(
+#         self, user_input: Optional[dict[str, Any]] = None
+#     ) -> dict[str, Any]:  # type: ignore[override]
+#         """Manage the options."""
+#         # For now, no options to manage
+#         return self.async_abort(reason="not_supported")

--- a/custom_components/mobile_alerts/config_flow.py
+++ b/custom_components/mobile_alerts/config_flow.py
@@ -315,25 +315,3 @@ class MobileAlertsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "device_id": self._device_id or "unknown",
             },
         )
-
-    # @staticmethod
-    # def async_get_options_flow(
-    #     config_entry: config_entries.ConfigEntry,
-    # ) -> config_entries.OptionsFlow:
-    #     """Get the options flow for this config entry."""
-    #     return OptionsFlowHandler(config_entry)
-
-
-# class OptionsFlowHandler(config_entries.OptionsFlow):
-#     """Handle options for Mobile Alerts."""
-
-#     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-#         """Initialize options flow."""
-#         self.config_entry = config_entry
-
-#     async def async_step_init(
-#         self, user_input: Optional[dict[str, Any]] = None
-#     ) -> dict[str, Any]:  # type: ignore[override]
-#         """Manage the options."""
-#         # For now, no options to manage
-#         return self.async_abort(reason="not_supported")

--- a/custom_components/mobile_alerts/device.py
+++ b/custom_components/mobile_alerts/device.py
@@ -137,6 +137,12 @@ DEVICE_MODELS: Final = {
         },
         "description": "4-channel wireless switch with key press monitoring",
     },
+    "TFA_30.3060.01:IT": {
+        "name": "TFA KLIMA@HOME 30.3060.01",
+        "display_name": "Wireless Thermo-Hygrometer with 3 sensors",
+        "measurement_keys": {"t1", "t2", "t3", "t4", "h1", "h2", "h3", "h4"},
+        "description": "Temperature, humidity 1 internal sensor and up to 3 external sensors",
+    },
     # MA10870 (Voltage Monitor) - measurement keys unknown, excluded from detection
 }
 

--- a/custom_components/mobile_alerts/device.py
+++ b/custom_components/mobile_alerts/device.py
@@ -138,10 +138,16 @@ DEVICE_MODELS: Final = {
         "description": "4-channel wireless switch with key press monitoring",
     },
     "TFA_30.3060.01:IT": {
-        "name": "TFA KLIMA@HOME 30.3060.01",
+        "name": "TFA Dostmann KLIMA@HOME 30.3060.01",
         "display_name": "Wireless Thermo-Hygrometer with 3 sensors",
         "measurement_keys": {"t1", "t2", "t3", "t4", "h1", "h2", "h3", "h4"},
         "description": "Temperature, humidity 1 internal sensor and up to 3 external sensors",
+    },
+    "TFA_30.3303.02": {
+        "name": "TFA Dostmann Temperature/Humidity Transmitter WEATHERHUB",
+        "display_name": "TFA Dostmann Thermo-Hygrometer Transmitter for WEATHERHUB",
+        "measurement_keys": {"t1", "h"},
+        "description": "Wireless temperature and humidity transmitter for WEATHERHUB system",
     },
     # MA10870 (Voltage Monitor) - measurement keys unknown, excluded from detection
 }
@@ -344,7 +350,7 @@ class MobileAlertsDevice:
         return DeviceInfo(
             identifiers=identifiers,
             name=self.name,
-            manufacturer="Mobile Alerts",
+            manufacturer="Mobile Alerts / TFA Dostmann",
             model=self.device_type,
         )
 

--- a/custom_components/mobile_alerts/device.py
+++ b/custom_components/mobile_alerts/device.py
@@ -27,48 +27,56 @@ DEVICE_MODELS: Final = {
         "display_name": "Wireless Thermometer",
         "measurement_keys": {"t1"},
         "description": "Temperature sensor",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10101": {
         "name": "MA 10101",
         "display_name": "Wireless Thermometer with Cable Sensor",
         "measurement_keys": {"t1", "t2"},
         "description": "Internal and external temperature",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10120": {
         "name": "MA 10120",
         "display_name": "Wireless Thermometer",
         "measurement_keys": {"t1"},
         "description": "Temperature sensor",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10200": {
         "name": "MA 10200",
         "display_name": "Wireless Thermo-Hygrometer",
         "measurement_keys": {"t1", "h"},
         "description": "Temperature and humidity",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10230": {
         "name": "MA 10230",
         "display_name": "Wireless Room Climate Station",
         "measurement_keys": {"t1", "h", "h3havg", "h24havg", "h7davg", "h30davg"},
         "description": "Temperature and humidity",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10238": {
         "name": "MA 10238",
         "display_name": "Wireless Air Pressure Monitor",
         "measurement_keys": {"t1", "h", "ap"},
         "description": "Temperature, humidity, and air pressure",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10241": {
         "name": "MA 10241",
         "display_name": "Wireless Thermo-Hygrometer",
         "measurement_keys": {"t1", "h"},
         "description": "Temperature and humidity",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10300": {
         "name": "MA 10300 / MA 10320",
         "display_name": "Wireless Thermo-Hygrometer with Cable Sensor",
         "measurement_keys": {"t1", "t2", "h"},
         "description": "Temperature (internal/cable) and humidity",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10350": {
         "name": "MA 10350",
@@ -79,48 +87,56 @@ DEVICE_MODELS: Final = {
             "h",
         },  # t2 = water level (NOT cable temperature like MA10300)
         "description": "Temperature, humidity, and water detection",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10402": {
         "name": "MA 10402",
         "display_name": "Wireless CO2 Monitor",
         "measurement_keys": {"t1", "t2", "h", "ppm"},
         "description": "Temperature, humidity, and CO2 monitoring",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10410": {
         "name": "MA 10410",
         "display_name": "Weather Station",
         "measurement_keys": {"t1", "t2", "h", "h2"},
         "description": "Temperature indoor, humidity indoor, temperature outdoor, humidity outdoor",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10450": {
         "name": "MA 10450",
         "display_name": "Wireless Temperature Station",
         "measurement_keys": {"h1"},
         "description": "Humidity sensor",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10650": {
         "name": "MA 10650",
         "display_name": "Wireless Rain Gauge",
         "measurement_keys": {"t1", "r", "rf"},
         "description": "Rainfall measurement and flip counter",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10660": {
         "name": "MA 10660",
         "display_name": "Wireless Anemometer",
         "measurement_keys": {"ws", "wg", "wd"},
         "description": "Wind speed, gust, and direction",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10700": {
         "name": "MA 10700",
         "display_name": "Wireless Thermo-Hygrometer with Pool Sensor",
         "measurement_keys": {"t1", "h1", "t2"},
         "description": "Temperature, humidity, and pool temperature",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10800": {
         "name": "MA 10800",
         "display_name": "Wireless Contact Sensor",
         "measurement_keys": {"w"},
         "description": "Window/door contact detection",
+        "manufacturer": "Mobile Alerts",
     },
     "MA10880": {
         "name": "MA 10880",
@@ -136,18 +152,21 @@ DEVICE_MODELS: Final = {
             "kp4c",
         },
         "description": "4-channel wireless switch with key press monitoring",
+        "manufacturer": "Mobile Alerts",
     },
     "TFA_30.3060.01:IT": {
-        "name": "TFA Dostmann KLIMA@HOME 30.3060.01",
-        "display_name": "Wireless Thermo-Hygrometer with 3 sensors",
+        "name": "TFA 30.3060.01",
+        "display_name": "TFA Dostmann KLIMA@HOME Thermo-Hygrometer with 3 sensors",
         "measurement_keys": {"t1", "t2", "t3", "t4", "h1", "h2", "h3", "h4"},
         "description": "Temperature, humidity 1 internal sensor and up to 3 external sensors",
+        "manufacturer": "TFA Dostmann",
     },
     "TFA_30.3303.02": {
-        "name": "TFA Dostmann Temperature/Humidity Transmitter WEATHERHUB",
+        "name": "TFA 30.3303",
         "display_name": "TFA Dostmann Thermo-Hygrometer Transmitter for WEATHERHUB",
         "measurement_keys": {"t1", "h"},
         "description": "Wireless temperature and humidity transmitter for WEATHERHUB system",
+        "manufacturer": "TFA Dostmann",
     },
     # MA10870 (Voltage Monitor) - measurement keys unknown, excluded from detection
 }
@@ -331,12 +350,14 @@ class MobileAlertsDevice:
         device_type: str,
         name: str,
         phone_id: str | None = None,
+        manufacturer: str | None = None,
     ) -> None:
         """Initialize device."""
         self.device_id = device_id
         self.device_type = device_type
         self.name = name
         self.phone_id = phone_id
+        self.manufacturer = manufacturer or "Mobile Alerts"
 
     @property
     def unique_id(self) -> str:
@@ -350,7 +371,7 @@ class MobileAlertsDevice:
         return DeviceInfo(
             identifiers=identifiers,
             name=self.name,
-            manufacturer="Mobile Alerts / TFA Dostmann",
+            manufacturer=self.manufacturer,
             model=self.device_type,
         )
 
@@ -370,6 +391,7 @@ class MobileAlertsDeviceManager:
         device_type: str,
         name: str,
         phone_id: str | None = None,
+        manufacturer: str | None = None,
     ) -> MobileAlertsDevice:
         """Add or update a device."""
         device = MobileAlertsDevice(
@@ -377,6 +399,7 @@ class MobileAlertsDeviceManager:
             device_type=device_type,
             name=name,
             phone_id=phone_id,
+            manufacturer=manufacturer,
         )
 
         self._devices[device_id] = device

--- a/custom_components/mobile_alerts/manifest.json
+++ b/custom_components/mobile_alerts/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cestlagalere/mobilealerts/issues",
   "requirements": [],
-  "version": "2.1.0"
+  "version": "2.2.0"
 }

--- a/custom_components/mobile_alerts/sensor.py
+++ b/custom_components/mobile_alerts/sensor.py
@@ -351,20 +351,22 @@ async def async_setup_entry(
         model_info = DEVICE_MODELS.get(model_id, {})
         display_name = model_info.get("display_name", model_id)
         measurement_keys = model_info.get("measurement_keys", set())
+        manufacturer = model_info.get("manufacturer", "Mobile Alerts")
 
         _LOGGER.debug(
-            "Got model_info for %s (model_id=%s): display_name=%s, measurement_keys=%s",
+            "Got model_info for %s (model_id=%s): display_name=%s, measurement_keys=%s, manufacturer=%s",
             device_id,
             model_id,
             display_name,
             measurement_keys,
+            manufacturer,
         )
 
         # Create DeviceInfo with model information
         device_info = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
             name=device_name,
-            manufacturer="Mobile Alerts",
+            manufacturer=manufacturer,
             model=f"{model_id} - {display_name}",  # Now shows "MA10300 - Wireless Thermo-Hygrometer"
             serial_number=device_id,
         )

--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -2,7 +2,7 @@
 
 This document lists all Mobile Alerts devices supported by this Home Assistant integration. The integration automatically detects the device model based on the measurement data received from the API.
 
-## Device Models
+## Mobile Alerts Devices
 
 ### Temperature Sensors
 
@@ -28,12 +28,12 @@ This document lists all Mobile Alerts devices supported by this Home Assistant i
 
 ### Thermo-Hygrometers with Cable Sensor
 
-| Model             | Name                                           | Measurement Keys       | Description                                                              |
-| ----------------- | ---------------------------------------------- | ---------------------- | ------------------------------------------------------------------------ |
-| MA10300 / MA10320 | Wireless Thermo-Hygrometer with Cable Sensor   | `t1`, `t2`, `h1`       | Temperature (internal/cable) and humidity                                |
-| MA10350           | Wireless Thermo-Hygrometer with Water Detector | `t1`, `t2`, `h1`       | Temperature, humidity, and water detection (t2 indicates water presence) |
-| MA10410           | Wheater station Thermo-Hygrometer (wirless)    | `t1`, `t2`, `h1`, `h2` | Temperature, humidity, and water detection (t2 indicates water presence) |
-| MA10700           | Wireless Thermo-Hygrometer with Pool Sensor    | `t1`, `h1`, `t2`       | Temperature, humidity, and pool temperature                              |
+| Model             | Name                                           | Measurement Keys        | Description                                                                |
+| ----------------- | ---------------------------------------------- | ----------------------- | -------------------------------------------------------------------------- |
+| MA10300 / MA10320 | Wireless Thermo-Hygrometer with Cable Sensor   | `t1`, `t2`, `h1`        | Temperature (internal/cable) and humidity                                  |
+| MA10350           | Wireless Thermo-Hygrometer with Water Detector | `t1`, `t2`, `h1`        | Temperature, humidity, and water detection (t2 indicates water presence)   |
+| MA10410           | Wheater station Thermo-Hygrometer (wireless)   | `t1`, `t2`, `h1`, `h2`  |Temperature indoor, humidity indoor, temperature outdoor, humidity outdoor  |
+| MA10700           | Wireless Thermo-Hygrometer with Pool Sensor    | `t1`, `h1`, `t2`        | Temperature, humidity, and pool temperature                                |
 
 ### Thermo-Hygrometer with Air Pressure
 
@@ -70,6 +70,17 @@ This document lists all Mobile Alerts devices supported by this Home Assistant i
 | Model   | Name            | Measurement Keys                                               | Description                                         |
 | ------- | --------------- | -------------------------------------------------------------- | --------------------------------------------------- |
 | MA10880 | Wireless Switch | `kp1t`, `kp1c`, `kp2t`, `kp2c`, `kp3t`, `kp3c`, `kp4t`, `kp4c` | 4-channel wireless switch with key press monitoring |
+
+## TFA Dostmann Devices
+
+TFA Dostmann manufactures devices that use the same Mobile Alerts API and sensor technology. These devices are listed separately to distinguish them from the Mobile Alerts branded products.
+
+### TFA Thermo-Hygrometers
+
+| Model          | Name                                                              | Measurement Keys                           | Description                                            |
+| -------------- | ----------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------ |
+| TFA 30.3060.01 | TFA Dostmann KLIMA@HOME Thermo-Hygrometer with 3 sensors           | `t1`, `t2`, `t3`, `t4`, `h1`, `h2`, `h3`, `h4` | 1 internal + 3 external sensors for temperature/humidity |
+| TFA 30.3303.02 | TFA Dostmann Thermo-Hygrometer Transmitter for WEATHERHUB          | `t1`, `h`                                  | Wireless temperature and humidity transmitter          |
 
 ## Measurement Key Reference
 

--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -28,11 +28,12 @@ This document lists all Mobile Alerts devices supported by this Home Assistant i
 
 ### Thermo-Hygrometers with Cable Sensor
 
-| Model             | Name                                           | Measurement Keys | Description                                                              |
-| ----------------- | ---------------------------------------------- | ---------------- | ------------------------------------------------------------------------ |
-| MA10300 / MA10320 | Wireless Thermo-Hygrometer with Cable Sensor   | `t1`, `t2`, `h1` | Temperature (internal/cable) and humidity                                |
-| MA10350           | Wireless Thermo-Hygrometer with Water Detector | `t1`, `t2`, `h1` | Temperature, humidity, and water detection (t2 indicates water presence) |
-| MA10700           | Wireless Thermo-Hygrometer with Pool Sensor    | `t1`, `h1`, `t2` | Temperature, humidity, and pool temperature                              |
+| Model             | Name                                           | Measurement Keys       | Description                                                              |
+| ----------------- | ---------------------------------------------- | ---------------------- | ------------------------------------------------------------------------ |
+| MA10300 / MA10320 | Wireless Thermo-Hygrometer with Cable Sensor   | `t1`, `t2`, `h1`       | Temperature (internal/cable) and humidity                                |
+| MA10350           | Wireless Thermo-Hygrometer with Water Detector | `t1`, `t2`, `h1`       | Temperature, humidity, and water detection (t2 indicates water presence) |
+| MA10410           | Wheater station Thermo-Hygrometer (wirless)    | `t1`, `t2`, `h1`, `h2` | Temperature, humidity, and water detection (t2 indicates water presence) |
+| MA10700           | Wireless Thermo-Hygrometer with Pool Sensor    | `t1`, `h1`, `t2`       | Temperature, humidity, and pool temperature                              |
 
 ### Thermo-Hygrometer with Air Pressure
 

--- a/tests/test_device_model_detection.py
+++ b/tests/test_device_model_detection.py
@@ -280,7 +280,10 @@ class TestDeviceModelDetection:
             "h3",
             "h4",
         }
-        assert model_info["display_name"] == "Wireless Thermo-Hygrometer with 3 sensors"
+        assert (
+            model_info["display_name"]
+            == "TFA Dostmann KLIMA@HOME Thermo-Hygrometer with 3 sensors"
+        )
 
     def test_empty_measurement(self):
         """Test that empty measurement returns empty list."""
@@ -317,7 +320,13 @@ class TestDeviceModelDetection:
 
     def test_device_models_structure(self):
         """Test that all device models have required keys."""
-        required_keys = {"name", "display_name", "measurement_keys", "description"}
+        required_keys = {
+            "name",
+            "display_name",
+            "measurement_keys",
+            "description",
+            "manufacturer",
+        }
 
         for model_id, model_info in DEVICE_MODELS.items():
             assert isinstance(model_id, str), (
@@ -336,3 +345,4 @@ class TestDeviceModelDetection:
             assert isinstance(model_info["display_name"], str)
             assert isinstance(model_info["measurement_keys"], set)
             assert isinstance(model_info["description"], str)
+            assert isinstance(model_info["manufacturer"], str)

--- a/tests/test_device_model_detection.py
+++ b/tests/test_device_model_detection.py
@@ -250,6 +250,38 @@ class TestDeviceModelDetection:
             "kp4c",
         }
 
+    def test_tfa_30_3060_01_klima_home(self):
+        """Test detection of TFA KLIMA@HOME 30.3060.01 - Thermo-Hygrometer with 3 sensors."""
+        measurement = {
+            "ts": 1704067200,
+            "idx": "123ABC456",
+            "c": 0,
+            "lb": False,
+            "t1": 21.5,
+            "t2": 18.3,
+            "t3": 22.1,
+            "t4": 19.8,
+            "h1": 55.0,
+            "h2": 48.5,
+            "h3": 52.3,
+            "h4": 60.1,
+        }
+        result = find_all_matching_models(measurement)
+        assert len(result) > 0
+        model_id, model_info = result[0]
+        assert model_id == "TFA_30.3060.01:IT"
+        assert model_info["measurement_keys"] == {
+            "t1",
+            "t2",
+            "t3",
+            "t4",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+        }
+        assert model_info["display_name"] == "Wireless Thermo-Hygrometer with 3 sensors"
+
     def test_empty_measurement(self):
         """Test that empty measurement returns empty list."""
         result = find_all_matching_models({})


### PR DESCRIPTION
The release 2.2.0 changes the follwing parts:

- Solve issue #44 by adding the new device in device list
- Solve issue #47 by removing the unnecessary undefined options flow. The option settings icon was present, but a click produced error 500
- In issue #47 was a further TFA device mentioned. Also this has been added.
- In the "Device info" box of a device was the manufacturer always like "by Mobile Alerts". For now we have an entry "manufacturer" for each device list entry. So the TFA device is "by TFA Dostmann".
- Readme modified in installation section. Now we have the official blue install button "Open HACS Repository On My". Using it, sets the mobile alerts repository into HACS automatically.

