### PR TITLE
feat: MA10870 Power status sensor added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Back](./README.md)
 
+## v2.2.0 (Mar 06 2026)
+- **feat**: Add support for new device MA10870 AC power status sensor [[#51](https://github.com/CestLaGalere/mobilealerts/issues/51)]
+
 ## v2.1.0 (Dec 15 2025)
 
 - **fix**: Air pressure device MA10238 had wrong humidity key (error) [#40](https://github.com/CestLaGalere/mobilealerts/issues/40)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ integrates home assistant to the mobilealerts sensor reading service
 
 ## Version history
 
-see [Version History](ReleaseHistory.md)
+see [Version History](CHANGELOG.md)
 
 ## Installation
 
@@ -103,6 +103,7 @@ see [https://mobile-alerts.eu/info/public_server_api_documentation.pdf](https://
 | sc      | If the measurement occured because of a status                                                                                                                               |
 | ap      | The measured air pressure in hPa.                                                                                                                                            |
 | water   | water presence sensor (t2 of MA10350)                                                                                                                                        |
+| ac_power   | AC power sensor (t2 of MA10870)                                                                                                                                           |
 
 ## Measuring Rainfall Per Period (Hourly, Daily, Monthly, Yearly)
 

--- a/custom_components/mobile_alerts/device.py
+++ b/custom_components/mobile_alerts/device.py
@@ -141,6 +141,7 @@ DEVICE_MODELS: Final = {
     "MA10870": {
         "name": "MA 10870",
         "display_name": "Wireless Voltage Monitor",
+        "manufacturer": "Mobile Alerts",
         "measurement_keys": {"t1", "t2"},  # t2 = AC power status (0=on, 1=off)
         "description": "Temperature and AC mains power monitoring",
     },

--- a/custom_components/mobile_alerts/device.py
+++ b/custom_components/mobile_alerts/device.py
@@ -13,7 +13,7 @@ _LOGGER: Final = logging.getLogger(__name__)
 # Device model mapping based on mobile-alerts.eu website and API documentation
 # Maps model identifiers to device specifications
 # Measurement keys reference:
-# - t1: Internal temperature, t2: Cable/external temperature
+# - t1: Internal temperature, t2: Cable/external temperature or device-specific override
 # - h: Humidity (standard), h1: Humidity (alternative)
 # - ap: Air pressure
 # - r: Rainfall, rf: Rain flip counter
@@ -122,6 +122,12 @@ DEVICE_MODELS: Final = {
         "measurement_keys": {"w"},
         "description": "Window/door contact detection",
     },
+    "MA10870": {
+        "name": "MA 10870",
+        "display_name": "Wireless Voltage Monitor",
+        "measurement_keys": {"t1", "t2"},  # t2 = AC power status (0=on, 1=off)
+        "description": "Temperature and AC mains power monitoring",
+    },
     "MA10880": {
         "name": "MA 10880",
         "display_name": "Wireless Switch",
@@ -137,7 +143,6 @@ DEVICE_MODELS: Final = {
         },
         "description": "4-channel wireless switch with key press monitoring",
     },
-    # MA10870 (Voltage Monitor) - measurement keys unknown, excluded from detection
 }
 
 
@@ -280,6 +285,7 @@ def get_sensor_type_override(model_id: str, measurement_key: str) -> str | None:
     Some measurement keys have different meanings across models:
     - MA10300: t2 = cable temperature (TemperatureSensor)
     - MA10350: t2 = water level (WaterSensor)
+    - MA10870: t2 = AC mains power status (ACPowerSensor)
 
     This returns the sensor type to use, overriding MEASUREMENT_TYPE_MAP.
 
@@ -293,6 +299,10 @@ def get_sensor_type_override(model_id: str, measurement_key: str) -> str | None:
     # Model-specific overrides: return the sensor type to use
     overrides = {
         ("MA10350", "t2"): "water",  # MA10350: t2 is water level, not temperature
+        (
+            "MA10870",
+            "t2",
+        ): "ac_power",  # MA10870: t2 is AC mains power status, not temperature
     }
 
     override_key = (model_id, measurement_key)

--- a/custom_components/mobile_alerts/manifest.json
+++ b/custom_components/mobile_alerts/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cestlagalere/mobilealerts/issues",
   "requirements": [],
-  "version": "2.2.0"
+  "version": "2.3.0"
 }

--- a/custom_components/mobile_alerts/sensor.py
+++ b/custom_components/mobile_alerts/sensor.py
@@ -27,6 +27,7 @@ from .const import (
 from .coordinator import MobileAlertsCoordinator
 from .device import DEVICE_MODELS, get_sensor_type_override
 from .sensor_classes import (
+    MobileAlertsACPowerSensor,
     MobileAlertsBatterySensor,
     MobileAlertsContactSensor,
     MobileAlertsHumiditySensor,
@@ -82,6 +83,7 @@ MEASUREMENT_TYPE_MAP = {
     "wd_degrees": MobileAlertsWindDirectionDegreesSensor,
     "w": MobileAlertsContactSensor,  # Window/door contact sensor (Boolean True/False)
     "water": MobileAlertsWaterSensor,  # Water sensor (MA10350)
+    "ac_power": MobileAlertsACPowerSensor,  # AC mains power sensor (MA10870)
     # Generic sensor class for unmapped types (will use default parent class behavior)
     # This includes key press sensors from MA 10880 Wireless Switch
     "ap": MobileAlertsSensor,  # Air Pressure

--- a/custom_components/mobile_alerts/sensor_classes.py
+++ b/custom_components/mobile_alerts/sensor_classes.py
@@ -92,6 +92,7 @@ class MobileAlertsSensor(CoordinatorEntity, SensorEntity):
             "water": "Water Detected",
             "battery": "Battery",
             "last_seen": "Last Seen",
+            "ac_power": "AC Power",
             # Key press sensors (MA 10880 Wireless Switch)
             "kp1t": "Key Press 1 Type",
             "kp1c": "Key Press 1 Counter",
@@ -657,12 +658,11 @@ class MobileAlertsLastSeenSensor(MobileAlertsSensor):
 
         measurement_data = data["measurement"]
 
-        # Last seen is in 'c' field (when sensor last transmitted to receiver)
-        if "c" in measurement_data:
+        # Prefer 'c' (time received by gateway) over 'ts' (measurement timestamp).
+        # Some devices (e.g. MA10870) do not send 'c', so fall back to 'ts'.
+        timestamp_value = measurement_data.get("c") or measurement_data.get("ts")
+        if timestamp_value is not None:
             try:
-                # 'c' should be a timestamp
-                timestamp_value = measurement_data["c"]
-
                 # Convert timestamp to datetime object with timezone
                 if isinstance(timestamp_value, (int, float)):
                     # Unix timestamp - add UTC timezone
@@ -690,7 +690,7 @@ class MobileAlertsLastSeenSensor(MobileAlertsSensor):
             except (ValueError, TypeError, OSError) as e:
                 _LOGGER.warning(
                     "Could not parse last seen timestamp %s: %s",
-                    measurement_data.get("c"),
+                    timestamp_value,
                     e,
                 )
                 self._attr_native_value = None
@@ -811,6 +811,106 @@ class MobileAlertsWaterSensor(CoordinatorEntity, BinarySensorEntity):
 
         _LOGGER.debug(
             "MobileAlertsWaterSensor::extract_reading %s %s:%s",
+            self._attr_name,
+            self._attr_is_on,
+            self._attr_available,
+        )
+
+
+class MobileAlertsACPowerSensor(CoordinatorEntity, BinarySensorEntity):
+    """Implementation of a Mobile Alerts AC mains power sensor (MA10870).
+
+    Monitors whether AC mains power is present on the plug.
+    The API uses measurement key t2 with inverted logic:
+    t2=0 means AC is ON (power present), t2=1 means AC is OFF (power absent).
+    """
+
+    coordinator: MobileAlertsCoordinator
+
+    def __init__(
+        self,
+        coordinator: MobileAlertsCoordinator,
+        device: dict[str, str],
+        device_info: DeviceInfo,
+    ) -> None:
+        """Initialize the AC power sensor."""
+        super().__init__(coordinator)
+        self._device_class = None
+        self._type = device.get(CONF_TYPE, "ac_power")
+
+        self._attr_device_class = BinarySensorDeviceClass.POWER
+        self._device_id = device[CONF_DEVICE_ID]
+        self._device_name = device[CONF_NAME]
+        self._attr_device_info = device_info
+        self._id = self._device_id + self._type
+        self._attr_unique_id = self._id
+
+        type_label = "AC Power"
+        self._attr_name = f"{self._device_name} {type_label}"
+
+        self.extract_reading()
+        self._attr_attribution = ATTRIBUTION
+
+        _LOGGER.debug(
+            "MobileAlertsACPowerSensor::init ID %s, type=%s, name=%s",
+            self._id,
+            self._type,
+            self._attr_name,
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.extract_reading()
+        self.async_write_ha_state()
+
+    def extract_reading(self) -> None:
+        """Extract AC power state from coordinator."""
+        data = self.coordinator.get_reading(self._device_id)
+        self._attr_extra_state_attributes = data if data is not None else {}
+        self._attr_available = False
+        self._attr_is_on = False
+        if data is None:
+            return
+        if "measurement" not in data:
+            return
+
+        measurement_data = data["measurement"]
+        state = STATE_UNKNOWN
+        available = False
+
+        # "ac_power" is a sensor type override; the actual measurement key in the API is "t2"
+        measurement_key = "t2" if self._type == "ac_power" else self._type
+
+        if measurement_key in measurement_data:
+            state = measurement_data[measurement_key]
+            available = True
+
+        # Inverted logic: t2=0 means AC ON (power present), t2=1 means AC OFF
+        if state is not None and state != STATE_UNKNOWN:
+            try:
+                if isinstance(state, bool):
+                    # Boolean False = AC ON, True = AC OFF → invert
+                    self._attr_is_on = not state
+                else:
+                    # Int 0 = AC ON, 1 = AC OFF → is_on when t2 == 0
+                    self._attr_is_on = int(state) == 0
+                self._attr_available = available
+            except (ValueError, TypeError):
+                _LOGGER.warning(
+                    "Invalid AC power sensor value for %s: %s (type: %s)",
+                    self._attr_name,
+                    state,
+                    type(state).__name__,
+                )
+                self._attr_is_on = False
+                self._attr_available = False
+        else:
+            self._attr_is_on = False
+            self._attr_available = False
+
+        _LOGGER.debug(
+            "MobileAlertsACPowerSensor::extract_reading %s is_on=%s available=%s",
             self._attr_name,
             self._attr_is_on,
             self._attr_available,

--- a/custom_components/mobile_alerts/sensor_classes.py
+++ b/custom_components/mobile_alerts/sensor_classes.py
@@ -67,10 +67,44 @@ class MobileAlertsSensor(CoordinatorEntity, SensorEntity):
         self._id = self._device_id + self._type
         self._attr_unique_id = self._id
 
-        # Set display name based on sensor type
-        # This makes entity IDs more descriptive like "sensor.test1_temperature_t1"
-        # Must stay in sync with MEASUREMENT_TYPE_MAP in sensor.py
-        type_labels = {
+        # Enable entity name translation: HA prepends device name automatically when
+        # _attr_has_entity_name=True. _attr_translation_key maps to entity.sensor.{key}.name
+        # in the translation files. _attr_name is the English fallback.
+        # Must stay in sync with strings.json entity.sensor.* and MEASUREMENT_TYPE_MAP in sensor.py.
+        self._attr_has_entity_name = True
+
+        _type_translation_keys = {
+            "t1": "temperature_t1",
+            "t2": "temperature_t2",
+            "t3": "temperature_t3",
+            "t4": "temperature_t4",
+            "h": "humidity",
+            "h1": "humidity_1",
+            "h2": "humidity_2",
+            "h3": "humidity_3",
+            "h4": "humidity_4",
+            "r": "rain",
+            "rf": "rain_flips",
+            "ws": "wind_speed",
+            "wg": "wind_gust",
+            "wd": "wind_direction",
+            "wd_degrees": "wind_direction_degrees",
+            "ap": "pressure",
+            "ppm": "air_quality",
+            "w": "window",
+            "battery": "battery",
+            "last_seen": "last_seen",
+            # Key press sensors (MA 10880 Wireless Switch)
+            "kp1t": "kp1_type",
+            "kp1c": "kp1_count",
+            "kp2t": "kp2_type",
+            "kp2c": "kp2_count",
+            "kp3t": "kp3_type",
+            "kp3c": "kp3_count",
+            "kp4t": "kp4_type",
+            "kp4c": "kp4_count",
+        }
+        _type_fallback_names = {
             "t1": "Temperature T1",
             "t2": "Temperature T2",
             "t3": "Temperature T3",
@@ -81,18 +115,16 @@ class MobileAlertsSensor(CoordinatorEntity, SensorEntity):
             "h3": "Humidity 3",
             "h4": "Humidity 4",
             "r": "Rain",
-            "rf": "Rain Flow",
+            "rf": "Rain Counter",
             "ws": "Wind Speed",
             "wg": "Wind Gust",
             "wd": "Wind Direction",
-            "wd_degrees": "Wind Direction Degrees",
+            "wd_degrees": "Wind Direction (Degrees)",
             "ap": "Air Pressure",
             "ppm": "Air Quality",
             "w": "Window Contact",
-            "water": "Water Detected",
             "battery": "Battery",
             "last_seen": "Last Seen",
-            "ac_power": "AC Power",
             # Key press sensors (MA 10880 Wireless Switch)
             "kp1t": "Key Press 1 Type",
             "kp1c": "Key Press 1 Counter",
@@ -104,14 +136,23 @@ class MobileAlertsSensor(CoordinatorEntity, SensorEntity):
             "kp4c": "Key Press 4 Counter",
         }
 
-        type_label = type_labels.get(self._type, self._type.upper())
-        self._attr_name = f"{self._device_name} {type_label}"
+        self._attr_translation_key = _type_translation_keys.get(self._type)
+        # IMPORTANT: _attr_name must NOT be set when translation_key is defined.
+        # If _attr_name is set to any string, HA uses it directly and ignores
+        # translation_key entirely. Only set _attr_name for unknown types without
+        # a translation key, as a last-resort fallback.
+        if self._attr_translation_key is None:
+            self._attr_name = self._type.upper()
 
         self.extract_reading()
         self._attr_attribution = ATTRIBUTION
 
         _LOGGER.debug(
-            "MobileAlertsSensor::init ID %s, name=%s", self._id, self._attr_name
+            "MobileAlertsSensor::init ID=%s translation_key=%s has_entity_name=%s name=%s",
+            self._id,
+            self._attr_translation_key,
+            self._attr_has_entity_name,
+            getattr(self, "_attr_name", "<UNDEFINED>"),
         )
 
     @callback
@@ -157,7 +198,7 @@ class MobileAlertsSensor(CoordinatorEntity, SensorEntity):
 
         _LOGGER.debug(
             "MobileAlertsSensor::extract_reading %s %s:%s",
-            self._attr_name,
+            getattr(self, "_attr_name", self._id),
             self._attr_native_value,
             self._attr_available,
         )
@@ -466,7 +507,7 @@ class MobileAlertsWindDirectionDegreesSensor(MobileAlertsSensor):
 
         _LOGGER.debug(
             "MobileAlertsWindDirectionDegreesSensor::extract_reading %s %s:%s",
-            self._attr_name,
+            getattr(self, "_attr_name", self._id),
             self._attr_native_value,
             self._attr_available,
         )
@@ -612,7 +653,7 @@ class MobileAlertsBatterySensor(MobileAlertsSensor):
 
         _LOGGER.debug(
             "MobileAlertsBatterySensor::extract_reading %s %s:%s",
-            self._attr_name,
+            getattr(self, "_attr_name", self._id),
             self._attr_native_value,
             self._attr_available,
         )
@@ -660,7 +701,10 @@ class MobileAlertsLastSeenSensor(MobileAlertsSensor):
 
         # Prefer 'c' (time received by gateway) over 'ts' (measurement timestamp).
         # Some devices (e.g. MA10870) do not send 'c', so fall back to 'ts'.
-        timestamp_value = measurement_data.get("c") or measurement_data.get("ts")
+        if "c" in measurement_data:
+            timestamp_value = measurement_data.get("c")
+        else:
+            timestamp_value = measurement_data.get("ts")
         if timestamp_value is not None:
             try:
                 # Convert timestamp to datetime object with timezone
@@ -698,7 +742,7 @@ class MobileAlertsLastSeenSensor(MobileAlertsSensor):
 
         _LOGGER.debug(
             "MobileAlertsLastSeenSensor::extract_reading %s %s:%s",
-            self._attr_name,
+            getattr(self, "_attr_name", self._id),
             self._attr_native_value,
             self._attr_available,
         )
@@ -734,19 +778,18 @@ class MobileAlertsWaterSensor(CoordinatorEntity, BinarySensorEntity):
         self._id = self._device_id + self._type
         self._attr_unique_id = self._id
 
-        # Set display name based on sensor type
-        # Water sensor is only used with "water" type (MA10350 override for t2)
-        type_label = "Water Detected"
-        self._attr_name = f"{self._device_name} {type_label}"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "water"
+        # Do NOT set _attr_name — leaving it UNDEFINED lets HA use translation_key
 
         self.extract_reading()
         self._attr_attribution = ATTRIBUTION
 
         _LOGGER.debug(
-            "MobileAlertsWaterSensor::init ID %s, type=%s, name=%s",
+            "MobileAlertsWaterSensor::init ID=%s translation_key=%s has_entity_name=%s",
             self._id,
-            self._type,
-            self._attr_name,
+            self._attr_translation_key,
+            self._attr_has_entity_name,
         )
 
     @callback
@@ -799,7 +842,7 @@ class MobileAlertsWaterSensor(CoordinatorEntity, BinarySensorEntity):
             except (ValueError, TypeError):
                 _LOGGER.warning(
                     "Invalid water/contact sensor value for %s: %s (type: %s)",
-                    self._attr_name,
+                    getattr(self, "_attr_name", self._id),
                     state,
                     type(state).__name__,
                 )
@@ -811,7 +854,7 @@ class MobileAlertsWaterSensor(CoordinatorEntity, BinarySensorEntity):
 
         _LOGGER.debug(
             "MobileAlertsWaterSensor::extract_reading %s %s:%s",
-            self._attr_name,
+            getattr(self, "_attr_name", self._id),
             self._attr_is_on,
             self._attr_available,
         )
@@ -845,17 +888,18 @@ class MobileAlertsACPowerSensor(CoordinatorEntity, BinarySensorEntity):
         self._id = self._device_id + self._type
         self._attr_unique_id = self._id
 
-        type_label = "AC Power"
-        self._attr_name = f"{self._device_name} {type_label}"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "ac_power"
+        # Do NOT set _attr_name — leaving it UNDEFINED lets HA use translation_key
 
         self.extract_reading()
         self._attr_attribution = ATTRIBUTION
 
         _LOGGER.debug(
-            "MobileAlertsACPowerSensor::init ID %s, type=%s, name=%s",
+            "MobileAlertsACPowerSensor::init ID=%s translation_key=%s has_entity_name=%s",
             self._id,
-            self._type,
-            self._attr_name,
+            self._attr_translation_key,
+            self._attr_has_entity_name,
         )
 
     @callback
@@ -899,7 +943,7 @@ class MobileAlertsACPowerSensor(CoordinatorEntity, BinarySensorEntity):
             except (ValueError, TypeError):
                 _LOGGER.warning(
                     "Invalid AC power sensor value for %s: %s (type: %s)",
-                    self._attr_name,
+                    getattr(self, "_attr_name", self._id),
                     state,
                     type(state).__name__,
                 )
@@ -911,7 +955,7 @@ class MobileAlertsACPowerSensor(CoordinatorEntity, BinarySensorEntity):
 
         _LOGGER.debug(
             "MobileAlertsACPowerSensor::extract_reading %s is_on=%s available=%s",
-            self._attr_name,
+            getattr(self, "_attr_name", self._id),
             self._attr_is_on,
             self._attr_available,
         )
@@ -940,7 +984,9 @@ class MobileAlertsContactSensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_device_class = BinarySensorDeviceClass.OPENING
         self._device_id = device[CONF_DEVICE_ID]
         self._device_name = device[CONF_NAME]
-        self._attr_name = self._device_name
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "contact"
+        # Do NOT set _attr_name — leaving it UNDEFINED lets HA use translation_key
         self._attr_device_info = device_info
         self._id = self._device_id + self._type
         self._attr_unique_id = self._id
@@ -998,7 +1044,7 @@ class MobileAlertsContactSensor(CoordinatorEntity, BinarySensorEntity):
             except (ValueError, TypeError):
                 _LOGGER.warning(
                     "Invalid contact sensor value for %s: %s (type: %s)",
-                    self._attr_name,
+                    getattr(self, "_attr_name", self._id),
                     state,
                     type(state).__name__,
                 )
@@ -1010,7 +1056,7 @@ class MobileAlertsContactSensor(CoordinatorEntity, BinarySensorEntity):
 
         _LOGGER.debug(
             "MobileAlertsContactSensor::extract_reading %s %s:%s",
-            self._attr_name,
+            getattr(self, "_attr_name", self._id),
             self._attr_is_on,
             self._attr_available,
         )

--- a/custom_components/mobile_alerts/strings.json
+++ b/custom_components/mobile_alerts/strings.json
@@ -69,6 +69,11 @@
       "last_seen": {
         "name": "Last Seen"
       }
+    },
+    "binary_sensor": {
+      "ac_power": {
+        "name": "AC Power"
+      }
     }
   }
 }

--- a/custom_components/mobile_alerts/strings.json
+++ b/custom_components/mobile_alerts/strings.json
@@ -36,11 +36,35 @@
       "temperature": {
         "name": "Temperature"
       },
+      "temperature_t1": {
+        "name": "Temperature T1"
+      },
+      "temperature_t2": {
+        "name": "Temperature T2"
+      },
+      "temperature_t3": {
+        "name": "Temperature T3"
+      },
+      "temperature_t4": {
+        "name": "Temperature T4"
+      },
       "cable_temperature": {
         "name": "Cable Temperature"
       },
       "humidity": {
         "name": "Humidity"
+      },
+      "humidity_1": {
+        "name": "Humidity 1"
+      },
+      "humidity_2": {
+        "name": "Humidity 2"
+      },
+      "humidity_3": {
+        "name": "Humidity 3"
+      },
+      "humidity_4": {
+        "name": "Humidity 4"
       },
       "external_humidity": {
         "name": "External Humidity"
@@ -48,11 +72,20 @@
       "rain": {
         "name": "Rain"
       },
+      "rain_flips": {
+        "name": "Rain Counter Total"
+      },
       "wind_speed": {
         "name": "Wind Speed"
       },
       "wind_gust": {
         "name": "Wind Gust"
+      },
+      "wind_direction": {
+        "name": "Wind Direction"
+      },
+      "wind_direction_degrees": {
+        "name": "Wind Direction (Degrees)"
       },
       "pressure": {
         "name": "Air Pressure"
@@ -68,11 +101,41 @@
       },
       "last_seen": {
         "name": "Last Seen"
+      },
+      "kp1_type": {
+        "name": "Key Press 1 Type"
+      },
+      "kp1_count": {
+        "name": "Key Press 1 Counter"
+      },
+      "kp2_type": {
+        "name": "Key Press 2 Type"
+      },
+      "kp2_count": {
+        "name": "Key Press 2 Counter"
+      },
+      "kp3_type": {
+        "name": "Key Press 3 Type"
+      },
+      "kp3_count": {
+        "name": "Key Press 3 Counter"
+      },
+      "kp4_type": {
+        "name": "Key Press 4 Type"
+      },
+      "kp4_count": {
+        "name": "Key Press 4 Counter"
       }
     },
     "binary_sensor": {
       "ac_power": {
         "name": "AC Power"
+      },
+      "water": {
+        "name": "Water Detected"
+      },
+      "contact": {
+        "name": "Window Contact"
       }
     }
   }

--- a/custom_components/mobile_alerts/translations/de.json
+++ b/custom_components/mobile_alerts/translations/de.json
@@ -75,6 +75,11 @@
       "last_seen": {
         "name": "Zuletzt gesehen"
       }
+    },
+    "binary_sensor": {
+      "ac_power": {
+        "name": "Netzspannung"
+      }
     }
   }
 }

--- a/custom_components/mobile_alerts/translations/de.json
+++ b/custom_components/mobile_alerts/translations/de.json
@@ -33,11 +33,35 @@
       "temperature": {
         "name": "Temperatur"
       },
+      "temperature_t1": {
+        "name": "Temperatur T1"
+      },
+      "temperature_t2": {
+        "name": "Temperatur T2"
+      },
+      "temperature_t3": {
+        "name": "Temperatur T3"
+      },
+      "temperature_t4": {
+        "name": "Temperatur T4"
+      },
       "cable_temperature": {
         "name": "Kabeltemperatur"
       },
       "humidity": {
         "name": "Luftfeuchte"
+      },
+      "humidity_1": {
+        "name": "Luftfeuchte 1"
+      },
+      "humidity_2": {
+        "name": "Luftfeuchte 2"
+      },
+      "humidity_3": {
+        "name": "Luftfeuchte 3"
+      },
+      "humidity_4": {
+        "name": "Luftfeuchte 4"
       },
       "external_humidity": {
         "name": "Externe Luftfeuchte"
@@ -74,11 +98,41 @@
       },
       "last_seen": {
         "name": "Zuletzt gesehen"
+      },
+      "kp1_type": {
+        "name": "Taste 1 Typ"
+      },
+      "kp1_count": {
+        "name": "Taste 1 Zähler"
+      },
+      "kp2_type": {
+        "name": "Taste 2 Typ"
+      },
+      "kp2_count": {
+        "name": "Taste 2 Zähler"
+      },
+      "kp3_type": {
+        "name": "Taste 3 Typ"
+      },
+      "kp3_count": {
+        "name": "Taste 3 Zähler"
+      },
+      "kp4_type": {
+        "name": "Taste 4 Typ"
+      },
+      "kp4_count": {
+        "name": "Taste 4 Zähler"
       }
     },
     "binary_sensor": {
       "ac_power": {
         "name": "Netzspannung"
+      },
+      "water": {
+        "name": "Wasser erkannt"
+      },
+      "contact": {
+        "name": "Fensterkontakt"
       }
     }
   }

--- a/custom_components/mobile_alerts/translations/en.json
+++ b/custom_components/mobile_alerts/translations/en.json
@@ -74,6 +74,11 @@
       "last_seen": {
         "name": "Last Seen"
       }
+    },
+    "binary_sensor": {
+      "ac_power": {
+        "name": "AC Power"
+      }
     }
   }
 }

--- a/custom_components/mobile_alerts/translations/en.json
+++ b/custom_components/mobile_alerts/translations/en.json
@@ -32,11 +32,35 @@
       "temperature": {
         "name": "Temperature"
       },
+      "temperature_t1": {
+        "name": "Temperature T1"
+      },
+      "temperature_t2": {
+        "name": "Temperature T2"
+      },
+      "temperature_t3": {
+        "name": "Temperature T3"
+      },
+      "temperature_t4": {
+        "name": "Temperature T4"
+      },
       "cable_temperature": {
         "name": "Cable Temperature"
       },
       "humidity": {
         "name": "Humidity"
+      },
+      "humidity_1": {
+        "name": "Humidity 1"
+      },
+      "humidity_2": {
+        "name": "Humidity 2"
+      },
+      "humidity_3": {
+        "name": "Humidity 3"
+      },
+      "humidity_4": {
+        "name": "Humidity 4"
       },
       "external_humidity": {
         "name": "External Humidity"
@@ -73,11 +97,41 @@
       },
       "last_seen": {
         "name": "Last Seen"
+      },
+      "kp1_type": {
+        "name": "Key Press 1 Type"
+      },
+      "kp1_count": {
+        "name": "Key Press 1 Counter"
+      },
+      "kp2_type": {
+        "name": "Key Press 2 Type"
+      },
+      "kp2_count": {
+        "name": "Key Press 2 Counter"
+      },
+      "kp3_type": {
+        "name": "Key Press 3 Type"
+      },
+      "kp3_count": {
+        "name": "Key Press 3 Counter"
+      },
+      "kp4_type": {
+        "name": "Key Press 4 Type"
+      },
+      "kp4_count": {
+        "name": "Key Press 4 Counter"
       }
     },
     "binary_sensor": {
       "ac_power": {
         "name": "AC Power"
+      },
+      "water": {
+        "name": "Water Detected"
+      },
+      "contact": {
+        "name": "Window Contact"
       }
     }
   }

--- a/custom_components/mobile_alerts/translations/es.json
+++ b/custom_components/mobile_alerts/translations/es.json
@@ -33,11 +33,35 @@
       "temperature": {
         "name": "Temperatura"
       },
+      "temperature_t1": {
+        "name": "Temperatura T1"
+      },
+      "temperature_t2": {
+        "name": "Temperatura T2"
+      },
+      "temperature_t3": {
+        "name": "Temperatura T3"
+      },
+      "temperature_t4": {
+        "name": "Temperatura T4"
+      },
       "cable_temperature": {
         "name": "Temperatura del cable"
       },
       "humidity": {
         "name": "Humedad"
+      },
+      "humidity_1": {
+        "name": "Humedad 1"
+      },
+      "humidity_2": {
+        "name": "Humedad 2"
+      },
+      "humidity_3": {
+        "name": "Humedad 3"
+      },
+      "humidity_4": {
+        "name": "Humedad 4"
       },
       "external_humidity": {
         "name": "Humedad externa"
@@ -74,11 +98,41 @@
       },
       "last_seen": {
         "name": "Último visto"
+      },
+      "kp1_type": {
+        "name": "Tipo de pulsación 1"
+      },
+      "kp1_count": {
+        "name": "Contador de pulsación 1"
+      },
+      "kp2_type": {
+        "name": "Tipo de pulsación 2"
+      },
+      "kp2_count": {
+        "name": "Contador de pulsación 2"
+      },
+      "kp3_type": {
+        "name": "Tipo de pulsación 3"
+      },
+      "kp3_count": {
+        "name": "Contador de pulsación 3"
+      },
+      "kp4_type": {
+        "name": "Tipo de pulsación 4"
+      },
+      "kp4_count": {
+        "name": "Contador de pulsación 4"
       }
     },
     "binary_sensor": {
       "ac_power": {
         "name": "Corriente alterna"
+      },
+      "water": {
+        "name": "Agua detectada"
+      },
+      "contact": {
+        "name": "Contacto de ventana"
       }
     }
   }

--- a/custom_components/mobile_alerts/translations/es.json
+++ b/custom_components/mobile_alerts/translations/es.json
@@ -75,6 +75,11 @@
       "last_seen": {
         "name": "Último visto"
       }
+    },
+    "binary_sensor": {
+      "ac_power": {
+        "name": "Corriente alterna"
+      }
     }
   }
 }

--- a/custom_components/mobile_alerts/translations/fr.json
+++ b/custom_components/mobile_alerts/translations/fr.json
@@ -75,6 +75,11 @@
       "last_seen": {
         "name": "Vu pour la dernière fois"
       }
+    },
+    "binary_sensor": {
+      "ac_power": {
+        "name": "Courant secteur"
+      }
     }
   }
 }

--- a/custom_components/mobile_alerts/translations/fr.json
+++ b/custom_components/mobile_alerts/translations/fr.json
@@ -33,11 +33,35 @@
       "temperature": {
         "name": "Température"
       },
+      "temperature_t1": {
+        "name": "Température T1"
+      },
+      "temperature_t2": {
+        "name": "Température T2"
+      },
+      "temperature_t3": {
+        "name": "Température T3"
+      },
+      "temperature_t4": {
+        "name": "Température T4"
+      },
       "cable_temperature": {
         "name": "Température du câble"
       },
       "humidity": {
         "name": "Humidité"
+      },
+      "humidity_1": {
+        "name": "Humidité 1"
+      },
+      "humidity_2": {
+        "name": "Humidité 2"
+      },
+      "humidity_3": {
+        "name": "Humidité 3"
+      },
+      "humidity_4": {
+        "name": "Humidité 4"
       },
       "external_humidity": {
         "name": "Humidité externe"
@@ -74,11 +98,41 @@
       },
       "last_seen": {
         "name": "Vu pour la dernière fois"
+      },
+      "kp1_type": {
+        "name": "Type de touche 1"
+      },
+      "kp1_count": {
+        "name": "Compteur de touche 1"
+      },
+      "kp2_type": {
+        "name": "Type de touche 2"
+      },
+      "kp2_count": {
+        "name": "Compteur de touche 2"
+      },
+      "kp3_type": {
+        "name": "Type de touche 3"
+      },
+      "kp3_count": {
+        "name": "Compteur de touche 3"
+      },
+      "kp4_type": {
+        "name": "Type de touche 4"
+      },
+      "kp4_count": {
+        "name": "Compteur de touche 4"
       }
     },
     "binary_sensor": {
       "ac_power": {
         "name": "Courant secteur"
+      },
+      "water": {
+        "name": "Eau détectée"
+      },
+      "contact": {
+        "name": "Contact de fenêtre"
       }
     }
   }

--- a/custom_components/mobile_alerts/translations/pt.json
+++ b/custom_components/mobile_alerts/translations/pt.json
@@ -75,6 +75,11 @@
       "last_seen": {
         "name": "Visto por último"
       }
+    },
+    "binary_sensor": {
+      "ac_power": {
+        "name": "Corrente alternada"
+      }
     }
   }
 }

--- a/custom_components/mobile_alerts/translations/pt.json
+++ b/custom_components/mobile_alerts/translations/pt.json
@@ -33,11 +33,35 @@
       "temperature": {
         "name": "Temperatura"
       },
+      "temperature_t1": {
+        "name": "Temperatura T1"
+      },
+      "temperature_t2": {
+        "name": "Temperatura T2"
+      },
+      "temperature_t3": {
+        "name": "Temperatura T3"
+      },
+      "temperature_t4": {
+        "name": "Temperatura T4"
+      },
       "cable_temperature": {
         "name": "Temperatura do cabo"
       },
       "humidity": {
         "name": "Umidade"
+      },
+      "humidity_1": {
+        "name": "Umidade 1"
+      },
+      "humidity_2": {
+        "name": "Umidade 2"
+      },
+      "humidity_3": {
+        "name": "Umidade 3"
+      },
+      "humidity_4": {
+        "name": "Umidade 4"
       },
       "external_humidity": {
         "name": "Umidade externa"
@@ -74,11 +98,41 @@
       },
       "last_seen": {
         "name": "Visto por último"
+      },
+      "kp1_type": {
+        "name": "Tipo de toque 1"
+      },
+      "kp1_count": {
+        "name": "Contador de toque 1"
+      },
+      "kp2_type": {
+        "name": "Tipo de toque 2"
+      },
+      "kp2_count": {
+        "name": "Contador de toque 2"
+      },
+      "kp3_type": {
+        "name": "Tipo de toque 3"
+      },
+      "kp3_count": {
+        "name": "Contador de toque 3"
+      },
+      "kp4_type": {
+        "name": "Tipo de toque 4"
+      },
+      "kp4_count": {
+        "name": "Contador de toque 4"
       }
     },
     "binary_sensor": {
       "ac_power": {
         "name": "Corrente alternada"
+      },
+      "water": {
+        "name": "Água detectada"
+      },
+      "contact": {
+        "name": "Contato de janela"
       }
     }
   }

--- a/custom_components/mobile_alerts/translations/zh-Hans.json
+++ b/custom_components/mobile_alerts/translations/zh-Hans.json
@@ -33,11 +33,35 @@
       "temperature": {
         "name": "温度"
       },
+      "temperature_t1": {
+        "name": "温度 T1"
+      },
+      "temperature_t2": {
+        "name": "温度 T2"
+      },
+      "temperature_t3": {
+        "name": "温度 T3"
+      },
+      "temperature_t4": {
+        "name": "温度 T4"
+      },
       "cable_temperature": {
         "name": "电缆温度"
       },
       "humidity": {
         "name": "湿度"
+      },
+      "humidity_1": {
+        "name": "湿度 1"
+      },
+      "humidity_2": {
+        "name": "湿度 2"
+      },
+      "humidity_3": {
+        "name": "湿度 3"
+      },
+      "humidity_4": {
+        "name": "湿度 4"
       },
       "external_humidity": {
         "name": "外部湿度"
@@ -74,11 +98,41 @@
       },
       "last_seen": {
         "name": "最后看到"
+      },
+      "kp1_type": {
+        "name": "按键 1 类型"
+      },
+      "kp1_count": {
+        "name": "按键 1 计数"
+      },
+      "kp2_type": {
+        "name": "按键 2 类型"
+      },
+      "kp2_count": {
+        "name": "按键 2 计数"
+      },
+      "kp3_type": {
+        "name": "按键 3 类型"
+      },
+      "kp3_count": {
+        "name": "按键 3 计数"
+      },
+      "kp4_type": {
+        "name": "按键 4 类型"
+      },
+      "kp4_count": {
+        "name": "按键 4 计数"
       }
     },
     "binary_sensor": {
       "ac_power": {
         "name": "交流电源"
+      },
+      "water": {
+        "name": "检测到水"
+      },
+      "contact": {
+        "name": "窗户接触"
       }
     }
   }

--- a/custom_components/mobile_alerts/translations/zh-Hans.json
+++ b/custom_components/mobile_alerts/translations/zh-Hans.json
@@ -75,6 +75,11 @@
       "last_seen": {
         "name": "最后看到"
       }
+    },
+    "binary_sensor": {
+      "ac_power": {
+        "name": "交流电源"
+      }
     }
   }
 }

--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -108,7 +108,7 @@ TFA Dostmann manufactures devices that use the same Mobile Alerts API and sensor
 
 ## Not Supported
 
-All known Mobile Alerts devices with documented measurement keys are now supported.
+All devices listed above are currently supported by this integration.
 
 ## Automatic Device Detection
 

--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -64,6 +64,12 @@ This document lists all Mobile Alerts devices supported by this Home Assistant i
 | ------- | ----------------------- | ---------------- | ----------------------------- |
 | MA10800 | Wireless Contact Sensor | `w`              | Window/door contact detection |
 
+### Voltage Monitor
+
+| Model   | Name                    | Measurement Keys | Description                                                                       |
+| ------- | ----------------------- | ---------------- | --------------------------------------------------------------------------------- |
+| MA10870 | Wireless Voltage Monitor | `t1`, `t2`      | Temperature and AC mains power presence (t2: 0=AC on, 1=AC off). Ambiguous with MA10101 — model must be selected manually in the config flow. |
+
 ### Wireless Switch
 
 | Model   | Name            | Measurement Keys                                               | Description                                         |
@@ -73,7 +79,7 @@ This document lists all Mobile Alerts devices supported by this Home Assistant i
 ## Measurement Key Reference
 
 - **t1**: Internal/primary temperature sensor (°C)
-- **t2**: External/cable temperature sensor (°C) or water detection flag (MA10350)
+- **t2**: External/cable temperature (°C), water detection flag (MA10350), or AC power status (MA10870: 0=on, 1=off)
 - **h1**: Relative humidity (%)
 - **ap**: Air pressure (hPa)
 - **r**: Rainfall accumulated (mm)
@@ -90,9 +96,7 @@ This document lists all Mobile Alerts devices supported by this Home Assistant i
 
 ## Not Supported
 
-- **MA10870** (Wireless Voltage Monitor) - Measurement keys unknown, not yet supported
-
-If you have such a device, please see chapter "Adding New Devices" and send the log by opening a new issue.
+All known Mobile Alerts devices with documented measurement keys are now supported.
 
 ## Automatic Device Detection
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ hassil>=3.0.0
 home-assistant-intents>=2025.11.0
 PyTurboJPEG>=1.8.0
 pymicro-vad>=1.0.0
+pysilero-vad>=1.0.0
 pyspeex-noise>=1.0.0
 mutagen>=1.0.0
 ha-ffmpeg>=1.0.0

--- a/tests/test_device_model_detection.py
+++ b/tests/test_device_model_detection.py
@@ -38,9 +38,10 @@ class TestDeviceModelDetection:
         }
         result = find_all_matching_models(measurement)
         assert len(result) > 0
-        model_id, model_info = result[0]
-        # Could match MA10101 - exact match
-        assert model_id == "MA10101"
+        # MA10101 and MA10870 both have {t1, t2} - ambiguous
+        model_ids = [model_id for model_id, _ in result]
+        assert "MA10101" in model_ids
+        assert "MA10870" in model_ids
 
     def test_ma10200_thermo_hygro(self):
         """Test detection of MA10200 - Thermo-Hygrometer."""
@@ -219,8 +220,40 @@ class TestDeviceModelDetection:
         assert model_id == "MA10402"
         assert model_info["measurement_keys"] == {"t1", "t2", "h", "ppm"}
 
+    def test_ma10870_voltage_monitor(self):
+        """Test detection of MA10870 - Wireless Voltage Monitor.
+
+        MA10870 and MA10101 both have {t1, t2}, so they are ambiguous.
+        The user must select the model in the config flow.
+        """
+        measurement = {
+            "t1": 15.9,
+            "t2": 0.0,  # t2=0 means AC is ON
+            "ts": 1772004382,
+            "idx": 5072504,
+            "c": 0,
+            "lb": False,
+        }
+        result = find_all_matching_models(measurement)
+        assert len(result) >= 2, "Should find both MA10101 and MA10870 (ambiguous)"
+        model_ids = [model_id for model_id, _ in result]
+        assert "MA10101" in model_ids
+        assert "MA10870" in model_ids
+
+    def test_ma10870_ac_off(self):
+        """Test detection of MA10870 with AC power off (t2=1)."""
+        measurement = {
+            "t1": 65295,
+            "t2": 1,  # t2=1 means AC is OFF
+            "ts": 1772225691,
+            "idx": 5080487,
+        }
+        result = find_all_matching_models(measurement)
+        assert len(result) >= 2, "Should find both MA10101 and MA10870 (ambiguous)"
+        model_ids = [model_id for model_id, _ in result]
+        assert "MA10870" in model_ids
+
     def test_ma10880_switch(self):
-        """Test detection of MA10880 - Wireless switch."""
         measurement = {
             "kp1t": 1,
             "kp1c": 5,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -56,7 +56,11 @@ async def test_temperature_sensor_initialization(
     )
 
     assert sensor._device_id == "A1B2C3D4E5F6"
-    assert sensor._attr_name == "Test Device Temperature T1"
+    assert (
+        not hasattr(sensor, "_attr_name") or sensor._attr_name is None
+    )  # UNDEFINED when translation_key is set
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_translation_key == "temperature_t1"
     assert sensor._type == "t1"
     assert sensor._device_class == SensorDeviceClass.TEMPERATURE
     assert sensor._attr_unique_id == "A1B2C3D4E5F6t1"
@@ -76,7 +80,9 @@ async def test_humidity_sensor_initialization(
     )
 
     assert sensor._device_id == "A1B2C3D4E5F6"
-    assert sensor._attr_name == "Test Device Humidity"
+    assert not hasattr(sensor, "_attr_name") or sensor._attr_name is None
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_translation_key == "humidity"
     assert sensor._type == "h"
     assert sensor._device_class == SensorDeviceClass.HUMIDITY
     assert sensor._attr_native_unit_of_measurement == PERCENTAGE
@@ -92,7 +98,9 @@ async def test_battery_sensor_initialization(
     )
 
     assert sensor._device_id == "A1B2C3D4E5F6"
-    assert sensor._attr_name == "Test Device Battery"
+    assert not hasattr(sensor, "_attr_name") or sensor._attr_name is None
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_translation_key == "battery"
     assert sensor._type == "battery"
     assert sensor._device_class is None  # Generic sensor for string values
     assert sensor._attr_native_unit_of_measurement is None  # String-based, no unit
@@ -109,7 +117,9 @@ async def test_last_seen_sensor_initialization(
     )
 
     assert sensor._device_id == "A1B2C3D4E5F6"
-    assert sensor._attr_name == "Test Device Last Seen"
+    assert not hasattr(sensor, "_attr_name") or sensor._attr_name is None
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_translation_key == "last_seen"
     assert sensor._type == "last_seen"
     assert sensor._device_class == SensorDeviceClass.TIMESTAMP
     assert sensor._attr_unique_id == "A1B2C3D4E5F6_last_seen"
@@ -402,7 +412,9 @@ async def test_ac_power_sensor_initialization(mock_coordinator, sample_device_in
     sensor = MobileAlertsACPowerSensor(mock_coordinator, device, sample_device_info)
 
     assert sensor._device_id == "173A4E25ABCD"
-    assert sensor._attr_name == "Voltage Monitor AC Power"
+    assert not hasattr(sensor, "_attr_name") or sensor._attr_name is None
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_translation_key == "ac_power"
     assert sensor._type == "ac_power"
     assert sensor._attr_device_class == BinarySensorDeviceClass.POWER
     assert sensor._attr_unique_id == "173A4E25ABCDac_power"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,6 +15,7 @@ from custom_components.mobile_alerts.sensor import (
     MobileAlertsBatterySensor,
     MobileAlertsLastSeenSensor,
 )
+from custom_components.mobile_alerts.sensor_classes import MobileAlertsACPowerSensor
 from custom_components.mobile_alerts.api import MobileAlertsApi
 from custom_components.mobile_alerts.const import DOMAIN
 
@@ -252,6 +253,34 @@ async def test_last_seen_sensor_extract_reading(
 
 
 @pytest.mark.asyncio
+async def test_last_seen_sensor_fallback_to_ts(
+    mock_coordinator, sample_device, sample_device_info
+):
+    """Test last seen sensor falls back to 'ts' when 'c' is absent (e.g. MA10870)."""
+    test_timestamp = 1772833234
+    mock_coordinator.get_reading.return_value = {
+        "deviceid": "173A4E25385D",
+        "measurement": {
+            "ts": test_timestamp,
+            "t1": 17.5,
+            "t2": 0.0,
+            # No 'c' field - MA10870 behaviour
+        },
+    }
+
+    sensor = MobileAlertsLastSeenSensor(
+        mock_coordinator, sample_device, sample_device_info
+    )
+    sensor.extract_reading()
+
+    assert isinstance(sensor._attr_native_value, datetime)
+    assert sensor._attr_native_value == datetime.fromtimestamp(
+        test_timestamp, tz=timezone.utc
+    )
+    assert sensor._attr_available
+
+
+@pytest.mark.asyncio
 async def test_sensor_no_data(mock_coordinator, sample_device, sample_device_info):
     """Test sensor behavior when no data is available."""
     mock_coordinator.get_reading.return_value = None
@@ -357,3 +386,83 @@ async def test_humidity_sensor_value_validation(sample_device_info):
 
     sensor._attr_native_value = -10  # Too low
     assert sensor.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_ac_power_sensor_initialization(mock_coordinator, sample_device_info):
+    """Test AC power sensor (MA10870) initialization."""
+    device = {
+        CONF_DEVICE_ID: "173A4E25ABCD",
+        CONF_NAME: "Voltage Monitor",
+        CONF_TYPE: "ac_power",
+    }
+
+    from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+    sensor = MobileAlertsACPowerSensor(mock_coordinator, device, sample_device_info)
+
+    assert sensor._device_id == "173A4E25ABCD"
+    assert sensor._attr_name == "Voltage Monitor AC Power"
+    assert sensor._type == "ac_power"
+    assert sensor._attr_device_class == BinarySensorDeviceClass.POWER
+    assert sensor._attr_unique_id == "173A4E25ABCDac_power"
+
+
+@pytest.mark.asyncio
+async def test_ac_power_sensor_ac_on(sample_device_info):
+    """Test AC power sensor when AC is ON (t2=0)."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_reading.return_value = {
+        "deviceid": "173A4E25ABCD",
+        "measurement": {"t1": 15.9, "t2": 0.0, "ts": 1772004382},
+    }
+
+    device = {
+        CONF_DEVICE_ID: "173A4E25ABCD",
+        CONF_NAME: "Voltage Monitor",
+        CONF_TYPE: "ac_power",
+    }
+    sensor = MobileAlertsACPowerSensor(mock_coordinator, device, sample_device_info)
+    sensor.extract_reading()
+
+    assert sensor._attr_is_on is True  # t2=0 → AC is ON (power present)
+    assert sensor._attr_available
+
+
+@pytest.mark.asyncio
+async def test_ac_power_sensor_ac_off(sample_device_info):
+    """Test AC power sensor when AC is OFF (t2=1)."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_reading.return_value = {
+        "deviceid": "173A4E25ABCD",
+        "measurement": {"t1": 65295, "t2": 1, "ts": 1772225691},
+    }
+
+    device = {
+        CONF_DEVICE_ID: "173A4E25ABCD",
+        CONF_NAME: "Voltage Monitor",
+        CONF_TYPE: "ac_power",
+    }
+    sensor = MobileAlertsACPowerSensor(mock_coordinator, device, sample_device_info)
+    sensor.extract_reading()
+
+    assert sensor._attr_is_on is False  # t2=1 → AC is OFF (power absent)
+    assert sensor._attr_available
+
+
+@pytest.mark.asyncio
+async def test_ac_power_sensor_no_data(sample_device_info):
+    """Test AC power sensor behavior when no data available."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_reading.return_value = None
+
+    device = {
+        CONF_DEVICE_ID: "173A4E25ABCD",
+        CONF_NAME: "Voltage Monitor",
+        CONF_TYPE: "ac_power",
+    }
+    sensor = MobileAlertsACPowerSensor(mock_coordinator, device, sample_device_info)
+    sensor.extract_reading()
+
+    assert sensor._attr_is_on is False
+    assert not sensor._attr_available


### PR DESCRIPTION
Issue #51 solved.

- New device type MA10870 = AC Power status sensor added

The device was in older releases only marked as comment because we hadn't example data to get the knowledge about this device.

- All labels weren't translated even if the translations files were there. There was an issue with label handling. It's fixed with this release and you labels (like humidity in the possible language, in my case German = Feuchtigkeit)
