### PR TITLE
fix: omit phoneid from lastmeasurement to avoid HTTP 400 (issue #54)

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-packages@sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd",
+      "integrity": "sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 [Back](./README.md)
 
+## v2.3.1 (June 30 2026)
+
+- **fix**: `lastmeasurement` requests no longer include `phoneid`. Some accounts received `HTTP 400` from the Mobile Alerts API when both `phoneid` and `deviceids` were sent (issue [#54](https://github.com/CestLaGalere/mobilealerts/issues/54)). Discovery still uses `phoneid`.
+
 ## v2.3.0 (Mar 06 2026)
+
 - **feat**: Add support for new device MA10870 AC power status sensor [[#51](https://github.com/CestLaGalere/mobilealerts/issues/51)]
 - **fix**: Translation of labels did not work because of wrong key handling in sensor classes.
 

--- a/custom_components/mobile_alerts/__init__.py
+++ b/custom_components/mobile_alerts/__init__.py
@@ -1,16 +1,14 @@
 """Mobile Alerts integration."""
 
-import json
 import logging
 from datetime import datetime
 from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEVICE_ID, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.helpers.typing import ConfigType
-import homeassistant.helpers.config_validation as cv
 
 from .const import DOMAIN
 

--- a/custom_components/mobile_alerts/api.py
+++ b/custom_components/mobile_alerts/api.py
@@ -25,7 +25,23 @@ class MobileAlertsApi:
     )
 
     def __init__(self, phone_id: str) -> None:
-        """Initialize the API client."""
+        """Initialize the API client.
+
+        Args:
+            phone_id: The Mobile Alerts phone/app id, or the sentinel
+                ``"ui_devices"`` for users who configured devices via the HA
+                UI without supplying a phone id.
+
+        Note:
+            The ``phone_id`` is **only** used by :meth:`discover_devices`.
+            The ``lastmeasurement`` endpoint deliberately omits it (see
+            ``_fetch_device`` / ``_fetch_batch`` below) because the upstream
+            API returns ``HTTP 400`` for some accounts when ``phoneid`` is
+            included alongside ``deviceids`` (issue #54). The ``phone_id`` is
+            still stored on the instance so a future feature (e.g. surfacing
+            alert flags per issue #22) can opt back in without re-plumbing
+            configuration.
+        """
         self._phone_id = phone_id
         self._device_ids: list[str] = []
         self._data: list[dict[str, Any]] | None = None
@@ -100,6 +116,21 @@ class MobileAlertsApi:
         Called from register_device() to fetch the newly registered device's data
         without re-fetching all previously registered devices.
 
+        Note:
+            We intentionally do **not** send ``phoneid`` with ``lastmeasurement``
+            requests. The Mobile Alerts API is inconsistent across accounts:
+            when the supplied ``phoneid`` is not linked to the queried
+            ``deviceids`` in MA's database the endpoint returns ``HTTP 400``
+            (issue #54). The ``phoneid`` is only required by
+            :meth:`discover_devices` and is therefore only attached there.
+
+            Side effect: response ``measurement`` payloads will not include
+            the alert-flag fields that are gated behind ``phoneid``. The HA
+            integration does not currently expose those flags as entities, so
+            this is a no-op for users. Re-introducing ``phoneid`` here is a
+            future opt-in (issue #22 follow-up) and should be guarded against
+            the same ``HTTP 400`` case before being shipped.
+
         Args:
             device_id: The device ID to fetch
 
@@ -108,8 +139,6 @@ class MobileAlertsApi:
         """
         _LOGGER.debug("Fetching initial data for device %s", device_id)
         request_payload = {"deviceids": device_id}
-        if self._phone_id and self._phone_id != "ui_devices":
-            request_payload["phoneid"] = self._phone_id
 
         response_data = await self._post_api_request(request_payload)
         if response_data:
@@ -129,6 +158,11 @@ class MobileAlertsApi:
         """Fetch all registered devices in a single batch request.
 
         This is used for regular 10-minute updates to minimize API calls.
+
+        Note:
+            Same rationale as :meth:`_fetch_device`: ``phoneid`` is omitted to
+            avoid ``HTTP 400`` for accounts where the phoneid is not linked to
+            the queried devices in MA's database (issue #54).
         """
         _LOGGER.debug("Fetching data from Mobile Alerts API (batch mode)")
 
@@ -137,8 +171,6 @@ class MobileAlertsApi:
             return
 
         request_payload = {"deviceids": ",".join(self._device_ids)}
-        if self._phone_id and self._phone_id != "ui_devices":
-            request_payload["phoneid"] = self._phone_id
 
         response_data = await self._post_api_request(request_payload)
         if response_data:

--- a/custom_components/mobile_alerts/manifest.json
+++ b/custom_components/mobile_alerts/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cestlagalere/mobilealerts/issues",
   "requirements": [],
-  "version": "2.3.0"
+  "version": "2.3.1"
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,11 @@
 """Tests for Mobile Alerts API."""
 
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from custom_components.mobile_alerts.api import MobileAlertsApi
+from custom_components.mobile_alerts.api import ApiError, MobileAlertsApi
 
 
 @pytest.mark.asyncio
@@ -135,3 +138,163 @@ def test_get_reading_nonexistent_device(fake_device_ids, mock_api_response):
 
     reading = api.get_reading("NONEXISTENT")
     assert reading is None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #54
+# ---------------------------------------------------------------------------
+# The Mobile Alerts ``lastmeasurement`` endpoint returns HTTP 400 for some
+# accounts when both ``phoneid`` and ``deviceids`` are sent (issue #54). The
+# integration must therefore omit ``phoneid`` from the measurement requests
+# while still attaching it to discovery requests. These tests guard the
+# payload shape so a future change cannot accidentally re-introduce the bug.
+
+
+def _make_response(status: int, body: dict) -> MagicMock:
+    """Build a mock aiohttp response context manager."""
+    response = MagicMock()
+    response.status = status
+    # The API client uses ``await response.text()`` and then ``json.loads``
+    # on the resulting string, so we only need to mock ``.text``.
+    response.text = AsyncMock(return_value=json.dumps(body))
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+    return response
+
+
+def _make_session(response: MagicMock) -> MagicMock:
+    """Build a mock aiohttp ClientSession that yields ``response``."""
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    post = MagicMock()
+    post.__aenter__ = AsyncMock(return_value=response)
+    post.__aexit__ = AsyncMock(return_value=None)
+    session.post = MagicMock(return_value=post)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_fetch_device_does_not_send_phoneid(fake_device_ids):
+    """``_fetch_device`` must not include ``phoneid`` in the request payload.
+
+    Regression test for issue #54: the MA API returns HTTP 400 for some
+    accounts when ``phoneid`` is sent alongside ``deviceids``.
+    """
+    api = MobileAlertsApi(phone_id="123456789")
+    api._device_ids.append(fake_device_ids[0])
+
+    response = _make_response(
+        200,
+        {"success": True, "devices": []},
+    )
+    session = _make_session(response)
+
+    with patch("custom_components.mobile_alerts.api.aiohttp.ClientSession") as cls:
+        cls.return_value = session
+        await api._fetch_device(fake_device_ids[0])
+
+    # Inspect the actual JSON body that was POSTed.
+    assert session.post.call_count == 1
+    _, kwargs = session.post.call_args
+    sent = json.loads(kwargs["data"])
+    assert "deviceids" in sent
+    assert sent["deviceids"] == fake_device_ids[0]
+    assert "phoneid" not in sent, (
+        "phoneid must not be sent on lastmeasurement requests (issue #54)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_batch_does_not_send_phoneid(fake_device_ids):
+    """``_fetch_batch`` must not include ``phoneid`` in the request payload.
+
+    Regression test for issue #54.
+    """
+    api = MobileAlertsApi(phone_id="123456789")
+    for device_id in fake_device_ids[:3]:
+        api._device_ids.append(device_id)
+
+    response = _make_response(200, {"success": True, "devices": []})
+    session = _make_session(response)
+
+    with patch("custom_components.mobile_alerts.api.aiohttp.ClientSession") as cls:
+        cls.return_value = session
+        await api._fetch_batch()
+
+    assert session.post.call_count == 1
+    _, kwargs = session.post.call_args
+    sent = json.loads(kwargs["data"])
+    assert "deviceids" in sent
+    assert sent["deviceids"] == ",".join(fake_device_ids[:3])
+    assert "phoneid" not in sent, (
+        "phoneid must not be sent on lastmeasurement requests (issue #54)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_device_with_ui_devices_sentinel_does_not_send_phoneid(
+    fake_device_ids,
+):
+    """``phoneid="ui_devices"`` is the default for UI-configured users.
+
+    Ensure the sentinel value is treated the same as no phoneid at all
+    (i.e. it never reaches the wire).
+    """
+    api = MobileAlertsApi(phone_id="ui_devices")
+    api._device_ids.append(fake_device_ids[0])
+
+    response = _make_response(200, {"success": True, "devices": []})
+    session = _make_session(response)
+
+    with patch("custom_components.mobile_alerts.api.aiohttp.ClientSession") as cls:
+        cls.return_value = session
+        await api._fetch_device(fake_device_ids[0])
+
+    _, kwargs = session.post.call_args
+    sent = json.loads(kwargs["data"])
+    assert "phoneid" not in sent
+    assert sent == {"deviceids": fake_device_ids[0]}
+
+
+@pytest.mark.asyncio
+async def test_discover_devices_still_sends_phoneid():
+    """Discovery must keep using ``phoneid`` so existing setups still work.
+
+    Only ``lastmeasurement`` is affected by issue #54; discovery is unchanged.
+    """
+    api = MobileAlertsApi(phone_id="123456789")
+    response = _make_response(200, {"success": True, "devices": []})
+    session = _make_session(response)
+
+    with patch("custom_components.mobile_alerts.api.aiohttp.ClientSession") as cls:
+        cls.return_value = session
+        await api.discover_devices()
+
+    _, kwargs = session.post.call_args
+    sent = json.loads(kwargs["data"])
+    assert sent.get("phoneid") == "123456789"
+    assert "deviceids" in sent
+
+
+@pytest.mark.asyncio
+async def test_fetch_batch_http_400_surfaces_as_api_error(fake_device_ids):
+    """An ``HTTP 400`` from the API must raise :class:`ApiError`.
+
+    Guards the behaviour the reporter in #54 observed: an unhandled 400
+    would silently leave sensors unavailable, which is exactly what we
+    want to prevent.
+    """
+    api = MobileAlertsApi(phone_id="123456789")
+    for device_id in fake_device_ids[:1]:
+        api._device_ids.append(device_id)
+
+    response = _make_response(400, {"success": False, "error": "bad request"})
+    session = _make_session(response)
+
+    with (
+        patch("custom_components.mobile_alerts.api.aiohttp.ClientSession") as cls,
+        pytest.raises(ApiError),
+    ):
+        cls.return_value = session
+        await api._fetch_batch()

--- a/tests/test_service_dump_raw_response.py
+++ b/tests/test_service_dump_raw_response.py
@@ -1,7 +1,6 @@
 """Tests for Mobile Alerts dump_raw_response service."""
 
-import json
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock, AsyncMock
 
 import pytest
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Summary

The Mobile Alerts `lastmeasurement` endpoint returns `HTTP 400` for some accounts when both `phoneid` and `deviceids` are sent. The reporter in issue #54 found that the request succeeds as soon as `phoneid` is dropped, while the same account is reachable through other clients.

This fix omits `phoneid` from the measurement requests in `_fetch_device()` and `_fetch_batch()`. `discover_devices()` is unchanged and still sends `phoneid` as before.

## Why

- `phoneid` is documented as optional in the upstream API spec — its only effect is to add alert-flag fields to the response.
- The integration does not expose those alert flags as entities (issue #22 was resolved via the generic `MobileAlertsSensor` fallback for `t1hiee`, `t1hise`, etc.).
- A retry-fallback on `HTTP 400` is unsafe because the upstream API rate-limits "invalid call" accumulation (5 invalid calls / 15 min → 403 for 15 min) — and `lastmeasurement` is hit on a 10-minute coordinator cycle, which would lock the IP out.

## Changes

- `custom_components/mobile_alerts/api.py` — drop `phoneid` from the measurement payload; expand docstrings on `__init__`, `_fetch_device`, `_fetch_batch` to explain the rationale and the future hook for issue #22 follow-ups.
- `tests/test_api.py` — 5 new regression tests guarding the payload shape: `_fetch_device` and `_fetch_batch` never include `phoneid`, the `ui_devices` sentinel is treated as no phoneid, `discover_devices` still sends it, and an `HTTP 400` surfaces as `ApiError`.
- `custom_components/mobile_alerts/__init__.py` — pre-existing F401 cleanup (unused `json`, `CONF_DEVICE_ID`, `homeassistant.helpers.config_validation`).
- `tests/test_service_dump_raw_response.py` — pre-existing F401 cleanup (unused `json`, `unittest.mock.patch`).
- `CHANGELOG.md` — v2.3.1 entry.
- `manifest.json` — bumped to 2.3.1.

## Test plan

- `pytest` → 63/63 pass
- `ruff check .` → clean
- `ruff format --check .` → clean

Fixes #54